### PR TITLE
Added Support for choosing a IPFS Provider (Infura or Quicknode)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2546,6 +2546,40 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
+    },
+    "node_modules/@libp2p/crypto": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-1.0.17.tgz",
+      "integrity": "sha512-Oeg0Eb/EvAho0gVkOgemXEgrVxWaT3x/DpFgkBdZ9qGxwq75w/E/oPc7souqBz+l1swfz37GWnwV7bIb4Xv5Ag==",
+      "dependencies": {
+        "@libp2p/interface-keys": "^1.0.2",
+        "@libp2p/interfaces": "^3.2.0",
+        "@noble/ed25519": "^1.6.0",
+        "@noble/secp256k1": "^1.5.4",
+        "multiformats": "^11.0.0",
+        "node-forge": "^1.1.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/crypto/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@libp2p/interface": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-0.1.2.tgz",
@@ -2610,6 +2644,15 @@
       "dependencies": {
         "multiformats": "^10.0.0"
       },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-keys": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-keys/-/interface-keys-1.0.8.tgz",
+      "integrity": "sha512-CJ1SlrwuoHMquhEEWS77E+4vv7hwB7XORkqzGQrPQmA9MRdIEZRS64bA4JqCLUDa4ltH0l+U1vp0oZHLT67NEA==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -3006,6 +3049,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/@multiformats/dns": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.5.tgz",
+      "integrity": "sha512-qP42WXdmK5D0KTMervvkE9N1l+1WbReMk9UwCmvE6iPterZgtNcNO5LQVfUrl0xqajQG9wDlom+a8YwA+sa5KQ==",
+      "dependencies": {
+        "@types/dns-packet": "^5.6.5",
+        "buffer": "^6.0.3",
+        "dns-packet": "^5.6.1",
+        "hashlru": "^2.3.0",
+        "p-queue": "^8.0.1",
+        "progress-events": "^1.0.0",
+        "uint8arrays": "^5.0.2"
+      }
+    },
+    "node_modules/@multiformats/dns/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+    },
+    "node_modules/@multiformats/dns/node_modules/uint8arrays": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+      "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
     "node_modules/@multiformats/multiaddr": {
       "version": "11.6.1",
       "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
@@ -3172,6 +3242,17 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@noble/ed25519": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
+      "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
     "node_modules/@noble/hashes": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
@@ -3182,6 +3263,17 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -3470,6 +3562,14 @@
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.20.7"
+      }
+    },
+    "node_modules/@types/dns-packet": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.5.tgz",
+      "integrity": "sha512-qXOC7XLOEe43ehtWJCMnQXvgcIpv6rPmQ1jXT98Ad8A3TB1Ue50jsCbSSSyuazScEuZ/Q026vHbrOTVkmwA+7Q==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/glob": {
@@ -5770,6 +5870,17 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/dns-packet": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -7120,6 +7231,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -7900,6 +8016,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
     },
     "node_modules/header-case": {
       "version": "1.0.1",
@@ -9147,15 +9268,11 @@
       }
     },
     "node_modules/it-pushable": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.1.tgz",
-      "integrity": "sha512-sLFz2Q0oyDCJpTciZog7ipP4vSftfPy3e6JnH6YyztRa1XqkpGQaafK3Jw/JlfEBtCXfnX9uVfcpu3xpSAqCVQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.3.tgz",
+      "integrity": "sha512-gzYnXYK8Y5t5b/BnJUr7glfQLO4U5vyb05gPx/TyTw+4Bv1zM9gFk4YsOrnulWefMewlphCjKkakFvj1y99Tcg==",
       "dependencies": {
         "p-defer": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
       }
     },
     "node_modules/it-stream-types": {
@@ -10899,6 +11016,329 @@
         "node": ">=6"
       }
     },
+    "node_modules/kubo-rpc-client": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/kubo-rpc-client/-/kubo-rpc-client-3.0.4.tgz",
+      "integrity": "sha512-MV8XFG8ikSPZJkzN/h50SH60kyFz6d3hBcHE/ChhLmbzT3TM8n/I9fq0+5IL5dFSwJo5YrpZqDgsFhNgMSeztg==",
+      "dependencies": {
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-json": "^10.0.0",
+        "@ipld/dag-pb": "^4.0.0",
+        "@libp2p/crypto": "^1.0.11",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/peer-id": "^2.0.0",
+        "@multiformats/multiaddr": "^12.1.10",
+        "any-signal": "^3.0.1",
+        "dag-jose": "^4.0.0",
+        "err-code": "^3.0.1",
+        "ipfs-core-utils": "^0.18.0",
+        "ipfs-utils": "^9.0.7",
+        "it-first": "^2.0.0",
+        "it-last": "^2.0.0",
+        "merge-options": "^3.0.4",
+        "multiformats": "^11.0.0",
+        "parse-duration": "^1.0.2",
+        "stream-to-it": "^0.2.4",
+        "uint8arrays": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/@ipld/dag-cbor": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.2.0.tgz",
+      "integrity": "sha512-N14oMy0q4gM6OuZkIpisKe0JBSjf1Jb39VI+7jMLiWX9124u1Z3Fdj/Tag1NA0cVxxqWDh0CqsjcVfOKtelPDA==",
+      "dependencies": {
+        "cborg": "^4.0.0",
+        "multiformats": "^13.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/@ipld/dag-cbor/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+    },
+    "node_modules/kubo-rpc-client/node_modules/@ipld/dag-json": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.2.0.tgz",
+      "integrity": "sha512-O9YLUrl3d3WbVz7v1WkajFkyfOLEe2Fep+wor4fgVe0ywxzrivrj437NiPcVyB+2EDdFn/Q7tCHFf8YVhDf8ZA==",
+      "dependencies": {
+        "cborg": "^4.0.0",
+        "multiformats": "^13.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/@ipld/dag-json/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+    },
+    "node_modules/kubo-rpc-client/node_modules/@ipld/dag-pb": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.1.0.tgz",
+      "integrity": "sha512-LJU451Drqs5zjFm7jI4Hs3kHlilOqkjcSfPiQgVsZnWaYb2C7YdfhnclrVn/X+ucKejlU9BL3+gXFCZUXkMuCg==",
+      "dependencies": {
+        "multiformats": "^13.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/@ipld/dag-pb/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+    },
+    "node_modules/kubo-rpc-client/node_modules/@libp2p/interface": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-1.1.5.tgz",
+      "integrity": "sha512-BjFgv/3VwEDNRcFKL4KW6g29IcUWUjaTJhyZVGWtodFuPjZsZHJgoQU7T/FFxDcfTdI90qpFbTREycOB+VL9NQ==",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.1.14",
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^13.1.0",
+        "progress-events": "^1.0.0",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/@libp2p/interface-keychain": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-keychain/-/interface-keychain-2.0.5.tgz",
+      "integrity": "sha512-mb7QNgn9fIvC7CaJCi06GJ+a6DN6RVT9TmEi0NmedZGATeCArPeWWG7r7IfxNVXb9cVOOE1RzV1swK0ZxEJF9Q==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/@libp2p/interface/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+    },
+    "node_modules/kubo-rpc-client/node_modules/@libp2p/peer-id": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-2.0.4.tgz",
+      "integrity": "sha512-gcOsN8Fbhj6izIK+ejiWsqiqKeJ2yWPapi/m55VjOvDa52/ptQzZszxQP8jUk93u36de92ATFXDfZR/Bi6eeUQ==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.2.0",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/@multiformats/multiaddr": {
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.2.1.tgz",
+      "integrity": "sha512-UwjoArBbv64FlaetV4DDwh+PUMfzXUBltxQwdh+uTYnGFzVa8ZfJsn1vt1RJlJ6+Xtrm3RMekF/B+K338i2L5Q==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interface": "^1.0.0",
+        "@multiformats/dns": "^1.0.3",
+        "multiformats": "^13.0.0",
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/@multiformats/multiaddr/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+    },
+    "node_modules/kubo-rpc-client/node_modules/@multiformats/multiaddr/node_modules/uint8arrays": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+      "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/@types/node": {
+      "version": "18.19.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.28.tgz",
+      "integrity": "sha512-J5cOGD9n4x3YGgVuaND6khm5x07MMdAKkRyXnjVR6KFhLMNh2yONGiP7Z+4+tBOt5mK+GvDTiacTOVGGpqiecw==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/cborg": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.1.4.tgz",
+      "integrity": "sha512-cCw4IuvCnwjsrgrCQoreyLZDETsfw+AtFz+OFwWbWgA1yALo4nHC3Vv+zhgcVB2bor6GFRZVxrZ7Yt/3hBFAkA==",
+      "bin": {
+        "cborg": "lib/bin.js"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/dag-jose": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dag-jose/-/dag-jose-4.0.0.tgz",
+      "integrity": "sha512-tw595L3UYoOUT9dSJPbBEG/qpRpw24kRZxa5SLRnlnr+g5L7O8oEs1d3W5TiVA1oJZbthVsf0Vi3zFN66qcEBA==",
+      "dependencies": {
+        "@ipld/dag-cbor": "^9.0.0",
+        "multiformats": "^11.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/interface-datastore": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
+      "integrity": "sha512-Q8LZS/jfFFHz6XyZazLTAc078SSCoa27ZPBOfobWdpDiFO7FqPA2yskitUJIhaCgxNK8C+/lMBUTBNfVIDvLiw==",
+      "dependencies": {
+        "interface-store": "^3.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/interface-store": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+      "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/ipfs-core-types": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.14.1.tgz",
+      "integrity": "sha512-4ujF8NlM9bYi2I6AIqPP9wfGGX0x/gRCkMoFdOQfxxrFg6HcAdfS+0/irK8mp4e7znOHWReOHeWqCGw+dAPwsw==",
+      "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
+      "dependencies": {
+        "@ipld/dag-pb": "^4.0.0",
+        "@libp2p/interface-keychain": "^2.0.0",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interface-peer-info": "^1.0.2",
+        "@libp2p/interface-pubsub": "^3.0.0",
+        "@multiformats/multiaddr": "^11.1.5",
+        "@types/node": "^18.0.0",
+        "interface-datastore": "^7.0.0",
+        "ipfs-unixfs": "^9.0.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/ipfs-core-types/node_modules/@multiformats/multiaddr": {
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+      "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "err-code": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/ipfs-core-utils": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.18.1.tgz",
+      "integrity": "sha512-P7jTpdfvlyBG3JR4o+Th3QJADlmXmwMxbkjszXry6VAjfSfLIIqXsdeYPoVRkV69GFEeQozuz2k/jR+U8cUH/Q==",
+      "deprecated": "js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details",
+      "dependencies": {
+        "@libp2p/logger": "^2.0.5",
+        "@multiformats/multiaddr": "^11.1.5",
+        "@multiformats/multiaddr-to-uri": "^9.0.1",
+        "any-signal": "^3.0.0",
+        "blob-to-it": "^2.0.0",
+        "browser-readablestream-to-it": "^2.0.0",
+        "err-code": "^3.0.1",
+        "ipfs-core-types": "^0.14.1",
+        "ipfs-unixfs": "^9.0.0",
+        "ipfs-utils": "^9.0.13",
+        "it-all": "^2.0.0",
+        "it-map": "^2.0.0",
+        "it-peekable": "^2.0.0",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
+        "multiformats": "^11.0.0",
+        "nanoid": "^4.0.0",
+        "parse-duration": "^1.0.0",
+        "timeout-abort-controller": "^3.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/ipfs-core-utils/node_modules/@multiformats/multiaddr": {
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.6.1.tgz",
+      "integrity": "sha512-doST0+aB7/3dGK9+U5y3mtF3jq85KGbke1QiH0KE1F5mGQ9y56mFebTeu2D9FNOm+OT6UHb8Ss8vbSnpGjeLNw==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "err-code": "^3.0.1",
+        "multiformats": "^11.0.0",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/ipfs-unixfs": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-9.0.1.tgz",
+      "integrity": "sha512-jh2CbXyxID+v3jLml9CqMwjdSS9ZRnsGfQGGPOfem0/hT/L48xUeTPvh7qLFWkZcIMhZtG+fnS1teei8x5uGBg==",
+      "dependencies": {
+        "err-code": "^3.0.1",
+        "protobufjs": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/it-stream-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+      "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/kubo-rpc-client/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.22",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
@@ -11424,6 +11864,14 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "engines": {
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-int64": {
@@ -11970,6 +12418,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/p-queue": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.0.1.tgz",
+      "integrity": "sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
+      "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -12371,6 +12845,15 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
+    "node_modules/progress-events": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.0.0.tgz",
+      "integrity": "sha512-zIB6QDrSbPfRg+33FZalluFIowkbV5Xh1xSuetjG+rlC5he6u2dc6VQJ0TbMdlN3R1RHdpOqxEFMKTnQ+itUwA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -12425,6 +12908,29 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/protons-runtime": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.4.0.tgz",
+      "integrity": "sha512-XfA++W/WlQOSyjUyuF5lgYBfXZUEMP01Oh1C2dSwZAlF2e/ZrMRPfWonXj6BGM+o8Xciv7w0tsRMKYwYEuQvaw==",
+      "dependencies": {
+        "uint8-varint": "^2.0.2",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/protons-runtime/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+    },
+    "node_modules/protons-runtime/node_modules/uint8arrays": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+      "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
+      "dependencies": {
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/proxy-agent": {
@@ -14616,24 +15122,46 @@
       }
     },
     "node_modules/uint8-varint": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.1.tgz",
-      "integrity": "sha512-euvmpuulJstK5+xNuI4S1KfnxJnbI5QP52RXIR3GZ3/ZMkOsEK2AgCtFpNvEQLXMxMx2o0qcyevK1fJwOZJagQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.4.tgz",
+      "integrity": "sha512-FwpTa7ZGA/f/EssWAb5/YV6pHgVF1fViKdW8cWaEarjB8t7NyofSWBdOTyFPaGuUG4gx3v1O3PQ8etsiOs3lcw==",
       "dependencies": {
         "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^4.0.2"
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/uint8-varint/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+    },
+    "node_modules/uint8-varint/node_modules/uint8arrays": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+      "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
+      "dependencies": {
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/uint8arraylist": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.3.tgz",
-      "integrity": "sha512-oEVZr4/GrH87K0kjNce6z8pSCzLEPqHNLNR5sj8cJOySrTP8Vb/pMIbZKLJGhQKxm1TiZ31atNrpn820Pyqpow==",
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.8.tgz",
+      "integrity": "sha512-vc1PlGOzglLF0eae1M8mLRTBivsvrGsdmJ5RbK3e+QRvRLOZfZhQROTwH/OfyF3+ZVUg9/8hE8bmKP2CvP9quQ==",
       "dependencies": {
-        "uint8arrays": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/uint8arraylist/node_modules/multiformats": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.1.0.tgz",
+      "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
+    },
+    "node_modules/uint8arraylist/node_modules/uint8arrays": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+      "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
+      "dependencies": {
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/uint8arrays": {
@@ -14677,6 +15205,11 @@
       "engines": {
         "node": ">=14.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/universalify": {
       "version": "2.0.0",
@@ -15187,6 +15720,7 @@
       "dependencies": {
         "axios": "^1.5.0",
         "ipfs-http-client": "59.0.0",
+        "kubo-rpc-client": "^3.0.4",
         "tsup": "7.2.0",
         "viem": "^1.10.14"
       },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "axios": "^1.5.0",
     "ipfs-http-client": "59.0.0",
+    "kubo-rpc-client": "^3.0.4",
     "tsup": "7.2.0",
     "viem": "^1.10.14"
   }

--- a/packages/client/src/__mocks__/kubo-rpc-client.js
+++ b/packages/client/src/__mocks__/kubo-rpc-client.js
@@ -1,0 +1,14 @@
+// Mocked Kubo RPC Client
+const create = jest.fn(config => {
+    // Mocked IPFS client instance
+    const ipfs = {
+        add: jest.fn(data => Promise.resolve({ path: '0xracoon' })), // Return '0xracoon' instead of the original data
+        pin: {
+            add: jest.fn(path => Promise.resolve(`Pin successful for ${path}`))
+        }
+    };
+
+    return ipfs;
+});
+
+module.exports = { create };

--- a/packages/client/src/__tests__/talentLayerClient.spec.ts
+++ b/packages/client/src/__tests__/talentLayerClient.spec.ts
@@ -36,8 +36,7 @@ describe('TalentLayerClient', () => {
         });
         const chainId = 137;
         const ipfsConfig = {
-            clientId: 'abcd',
-            clientSecret: 'abcde',
+            apiKey: 'abcd',
             baseUrl: 'www.example.com'
         }
         const viemConfig = {};
@@ -97,8 +96,7 @@ describe('TalentLayerClient:dev', () => {
         });
         const chainId = 137;
         const ipfsConfig = {
-            clientId: 'abcd',
-            clientSecret: 'abcde',
+            apiKey: 'abcd',
             baseUrl: 'www.example.com'
         }
         const viemConfig = {};

--- a/packages/client/src/__tests__/talentLayerClient.spec.ts
+++ b/packages/client/src/__tests__/talentLayerClient.spec.ts
@@ -8,7 +8,7 @@ import { Profile } from '../profile';
 import { Proposal } from '../proposals';
 import { Review } from '../reviews';
 import { Service } from '../services';
-import { CustomConfig, NetworkEnum } from '../types';
+import { CustomConfig, NetworkEnum, IPFSClientConfig } from '../types';
 import { testPlatformId } from '../__mocks__/fixtures';
 import TalentLayerID from '../contracts/ABI/TalentLayerID.json';
 import TalerLayerService from '../contracts/ABI/TalentLayerService.json';
@@ -29,57 +29,99 @@ jest.mock('ipfs-http-client', () => ({
 }));
 
 describe('TalentLayerClient', () => {
-    let client: any;
+    let clientQuicknode: any;
+    let clientInfura: any;
 
     beforeEach(() => {
         Object.defineProperty(globalThis, 'window', {
         });
         const chainId = 137;
-        const ipfsConfig = {
-            apiKey: 'abcd',
-            baseUrl: 'www.example.com'
-        }
+        const quicknodeConfig: IPFSClientConfig = {
+            provider: 'quicknode',
+            apiKey: 'your_quicknode_api_key',
+            baseUrl: 'www.quicknode.com'
+        };
+        const infuraConfig: IPFSClientConfig = {
+            provider: 'infura',
+            clientId: 'your_infura_client_id',
+            clientSecret: 'your_infura_client_secret',
+            baseUrl: 'https://ipfs.infura.io:5001/api/v0'
+        };
+        
         const viemConfig = {};
         const platformID = testPlatformId;
         const signatureApiUrl = 'www.example.com';
-        client = new TalentLayerClient({
+        
+        clientQuicknode = new TalentLayerClient({
             chainId: chainId,
-            ipfsConfig: ipfsConfig,
+            ipfsConfig: quicknodeConfig,
             platformId: testPlatformId,
             signatureApiUrl: signatureApiUrl,
             debug: false
-        })
+        });
+        clientInfura = new TalentLayerClient({
+            chainId: chainId,
+            ipfsConfig: infuraConfig,
+            platformId: testPlatformId,
+            signatureApiUrl: signatureApiUrl,
+            debug: false
+        });
 
 
     })
 
     describe('constructor', () => {
-        it('should be initialised successfully', async () => {
-            expect(client).toBeDefined()
+        it('should be initialised successfully (Quicknode)', async () => {
+            expect(clientQuicknode).toBeDefined()
+
+        })
+
+        it('should be initialised successfully (Infura)', async () => {
+            expect(clientInfura).toBeDefined()
 
         })
     })
 
     describe('getters', () => {
-        it('should return all domain specific getters', async () => {
-            expect(client.platform).toBeInstanceOf(Platform)
-            expect(client.erc20).toBeInstanceOf(ERC20)
-            expect(client.proposal).toBeInstanceOf(Proposal)
-            expect(client.disputes).toBeInstanceOf(Disputes)
-            expect(client.service).toBeInstanceOf(Service)
-            expect(client.profile).toBeInstanceOf(Profile)
-            expect(client.escrow).toBeInstanceOf(Escrow)
-            expect(client.review).toBeInstanceOf(Review)
+        it('should return all domain specific getters  (Quicknode)', async () => {
+            expect(clientQuicknode.platform).toBeInstanceOf(Platform)
+            expect(clientQuicknode.erc20).toBeInstanceOf(ERC20)
+            expect(clientQuicknode.proposal).toBeInstanceOf(Proposal)
+            expect(clientQuicknode.disputes).toBeInstanceOf(Disputes)
+            expect(clientQuicknode.service).toBeInstanceOf(Service)
+            expect(clientQuicknode.profile).toBeInstanceOf(Profile)
+            expect(clientQuicknode.escrow).toBeInstanceOf(Escrow)
+            expect(clientQuicknode.review).toBeInstanceOf(Review)
+        })
+        it('should return all domain specific getters (Infura)', async () => {
+            expect(clientInfura.platform).toBeInstanceOf(Platform)
+            expect(clientInfura.erc20).toBeInstanceOf(ERC20)
+            expect(clientInfura.proposal).toBeInstanceOf(Proposal)
+            expect(clientInfura.disputes).toBeInstanceOf(Disputes)
+            expect(clientInfura.service).toBeInstanceOf(Service)
+            expect(clientInfura.profile).toBeInstanceOf(Profile)
+            expect(clientInfura.escrow).toBeInstanceOf(Escrow)
+            expect(clientInfura.review).toBeInstanceOf(Review)
         })
     })
 
     describe('getChainConfig', () => {
-        it('should return the chain config based on the network id passed', () => {
+        it('should return the chain config based on the network id passed (Quicknode)', () => {
             // Arrange
             const networkId = NetworkEnum.MUMBAI
 
             // Act
-            const config = client.getChainConfig(networkId);
+            const config = clientQuicknode.getChainConfig(networkId);
+
+            // Assert
+            expect(config).toEqual(getChainConfig(networkId));
+        })
+        it('should return the chain config based on the network id passed (Infura)', () => {
+            // Arrange
+            const networkId = NetworkEnum.MUMBAI
+
+            // Act
+            const config = clientInfura.getChainConfig(networkId);
 
             // Assert
             expect(config).toEqual(getChainConfig(networkId));
@@ -89,16 +131,24 @@ describe('TalentLayerClient', () => {
 
 
 describe('TalentLayerClient:dev', () => {
-    let client: any;
+    let clientQuicknode: any;
+    let clientInfura: any;
 
     beforeEach(() => {
         Object.defineProperty(globalThis, 'window', {
         });
         const chainId = 137;
-        const ipfsConfig = {
-            apiKey: 'abcd',
-            baseUrl: 'www.example.com'
-        }
+        const quicknodeConfig: IPFSClientConfig = {
+            provider: 'quicknode',
+            apiKey: 'your_quicknode_api_key',
+            baseUrl: 'www.quicknode.com'
+        };
+        const infuraConfig: IPFSClientConfig = {
+            provider: 'infura',
+            clientId: 'your_infura_client_id',
+            clientSecret: 'your_infura_client_secret',
+            baseUrl: 'https://ipfs.infura.io:5001/api/v0'
+        };
         const viemConfig = {};
         const platformID = testPlatformId;
         const signatureApiUrl = 'www.example.com';
@@ -176,9 +226,16 @@ describe('TalentLayerClient:dev', () => {
             }
         }
 
-        client = new TalentLayerClient({
+        clientQuicknode = new TalentLayerClient({
             chainId: chainId,
-            ipfsConfig: ipfsConfig,
+            ipfsConfig: quicknodeConfig,
+            platformId: testPlatformId,
+            signatureApiUrl: signatureApiUrl,
+            customConfig: customConfig
+        })
+        clientInfura = new TalentLayerClient({
+            chainId: chainId,
+            ipfsConfig: infuraConfig,
             platformId: testPlatformId,
             signatureApiUrl: signatureApiUrl,
             customConfig: customConfig
@@ -186,35 +243,60 @@ describe('TalentLayerClient:dev', () => {
     })
 
     describe('constructor', () => {
-        it('should be initialised successfully', async () => {
-            expect(client).toBeDefined()
+        it('should be initialised successfully (Quicknode)', async () => {
+            expect(clientQuicknode).toBeDefined()
+
+        })
+        it('should be initialised successfully (Infura)', async () => {
+            expect(clientInfura).toBeDefined()
 
         })
     })
 
     describe('getters', () => {
-        it('should return all domain specific getters', async () => {
-            expect(client.platform).toBeInstanceOf(Platform)
-            expect(client.erc20).toBeInstanceOf(ERC20)
-            expect(client.proposal).toBeInstanceOf(Proposal)
-            expect(client.disputes).toBeInstanceOf(Disputes)
-            expect(client.service).toBeInstanceOf(Service)
-            expect(client.profile).toBeInstanceOf(Profile)
-            expect(client.escrow).toBeInstanceOf(Escrow)
-            expect(client.review).toBeInstanceOf(Review)
+        it('should return all domain specific getters (Quicknode)', async () => {
+            expect(clientQuicknode.platform).toBeInstanceOf(Platform)
+            expect(clientQuicknode.erc20).toBeInstanceOf(ERC20)
+            expect(clientQuicknode.proposal).toBeInstanceOf(Proposal)
+            expect(clientQuicknode.disputes).toBeInstanceOf(Disputes)
+            expect(clientQuicknode.service).toBeInstanceOf(Service)
+            expect(clientQuicknode.profile).toBeInstanceOf(Profile)
+            expect(clientQuicknode.escrow).toBeInstanceOf(Escrow)
+            expect(clientQuicknode.review).toBeInstanceOf(Review)
+        })
+
+        it('should return all domain specific getters (Infura)', async () => {
+            expect(clientInfura.platform).toBeInstanceOf(Platform)
+            expect(clientInfura.erc20).toBeInstanceOf(ERC20)
+            expect(clientInfura.proposal).toBeInstanceOf(Proposal)
+            expect(clientInfura.disputes).toBeInstanceOf(Disputes)
+            expect(clientInfura.service).toBeInstanceOf(Service)
+            expect(clientInfura.profile).toBeInstanceOf(Profile)
+            expect(clientInfura.escrow).toBeInstanceOf(Escrow)
+            expect(clientInfura.review).toBeInstanceOf(Review)
         })
     })
 
     describe('getChainConfig', () => {
-        it('should return the chain config irrespective of the network id passed', () => {
+        it('should return the chain config irrespective of the network id passed (Quicknode)', () => {
             // Arrange
             const networkId = NetworkEnum.MUMBAI
 
             // Act
-            const config = client.getChainConfig(networkId);
+            const config = clientQuicknode.getChainConfig(networkId);
 
             // Assert
-            expect(config).toEqual(client.customConfig.contractConfig);
+            expect(config).toEqual(clientQuicknode.customConfig.contractConfig);
+        })
+        it('should return the chain config irrespective of the network id passed (Infura)', () => {
+            // Arrange
+            const networkId = NetworkEnum.MUMBAI
+
+            // Act
+            const config = clientInfura.getChainConfig(networkId);
+
+            // Assert
+            expect(config).toEqual(clientInfura.customConfig.contractConfig);
         })
     })
 })

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -43,10 +43,22 @@ export class TalentLayerClient {
     this.logger.info('Client Initialising', config);
     this.platformID = config.platformId;
     this.graphQlClient = new GraphQLClient(getGraphQLConfig(config.chainId));
-    this.ipfsClient = new IPFSClient({
-      baseUrl: config.ipfsConfig.baseUrl,
-      apiKey: config.ipfsConfig.apiKey,
-    });
+    if (config.ipfsConfig.provider === 'quicknode') {
+      this.ipfsClient = new IPFSClient({
+        provider: config.ipfsConfig.provider, 
+        baseUrl: config.ipfsConfig.baseUrl,
+        apiKey: config.ipfsConfig.apiKey,
+      });
+    } else if (config.ipfsConfig.provider === 'infura') {
+      this.ipfsClient = new IPFSClient({
+        provider: config.ipfsConfig.provider, 
+        baseUrl: config.ipfsConfig.baseUrl,
+        clientId: config.ipfsConfig.clientId,
+        clientSecret: config.ipfsConfig.clientSecret,
+      });
+    } else {
+      throw new Error('Unsupported IPFS provider or IPFS provider not defined.');
+    }    
     this.viemClient = new ViemClient(config.chainId, config.walletConfig || {}, this.logger);
     this.chainId = config.chainId;
     this.signatureApiUrl = config?.signatureApiUrl;

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -45,8 +45,7 @@ export class TalentLayerClient {
     this.graphQlClient = new GraphQLClient(getGraphQLConfig(config.chainId));
     this.ipfsClient = new IPFSClient({
       baseUrl: config.ipfsConfig.baseUrl,
-      clientId: config.ipfsConfig.clientId,
-      clientSecret: config.ipfsConfig.clientSecret,
+      apiKey: config.ipfsConfig.apiKey,
     });
     this.viemClient = new ViemClient(config.chainId, config.walletConfig || {}, this.logger);
     this.chainId = config.chainId;

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -43,22 +43,32 @@ export class TalentLayerClient {
     this.logger.info('Client Initialising', config);
     this.platformID = config.platformId;
     this.graphQlClient = new GraphQLClient(getGraphQLConfig(config.chainId));
-    if (config.ipfsConfig.provider === 'quicknode') {
-      this.ipfsClient = new IPFSClient({
-        provider: config.ipfsConfig.provider, 
-        baseUrl: config.ipfsConfig.baseUrl,
-        apiKey: config.ipfsConfig.apiKey,
-      });
-    } else if (config.ipfsConfig.provider === 'infura') {
-      this.ipfsClient = new IPFSClient({
-        provider: config.ipfsConfig.provider, 
-        baseUrl: config.ipfsConfig.baseUrl,
-        clientId: config.ipfsConfig.clientId,
-        clientSecret: config.ipfsConfig.clientSecret,
-      });
-    } else {
-      throw new Error('Unsupported IPFS provider or IPFS provider not defined.');
-    }    
+    switch (config.ipfsConfig.provider) {
+      case 'quicknode':
+        this.ipfsClient = new IPFSClient({
+          provider: config.ipfsConfig.provider,
+          baseUrl: config.ipfsConfig.baseUrl,
+          apiKey: config.ipfsConfig.apiKey,
+        });
+        break;
+      case 'infura':
+        this.ipfsClient = new IPFSClient({
+          provider: config.ipfsConfig.provider,
+          baseUrl: config.ipfsConfig.baseUrl,
+          clientId: config.ipfsConfig.clientId,
+          clientSecret: config.ipfsConfig.clientSecret,
+        });
+        break;
+      default:
+        // Assume Infura if no provider is defined
+        this.ipfsClient = new IPFSClient({
+          provider: 'infura',
+          baseUrl: config.ipfsConfig.baseUrl,
+          clientId: config.ipfsConfig.clientId,
+          clientSecret: config.ipfsConfig.clientSecret,
+        });
+        break;
+    }
     this.viemClient = new ViemClient(config.chainId, config.walletConfig || {}, this.logger);
     this.chainId = config.chainId;
     this.signatureApiUrl = config?.signatureApiUrl;

--- a/packages/client/src/ipfs/__tests__/ipfs.spec.ts
+++ b/packages/client/src/ipfs/__tests__/ipfs.spec.ts
@@ -1,20 +1,19 @@
 import IPFSClient from "..";
 import { IPFSClientConfig } from "../../types";
 
-// Mock axios and fetch globally
-jest.mock('axios');
+// Mock fetch globally
 global.fetch = jest.fn();
 
 describe('IPFSClient', () => {
     let ipfsClientConfig: IPFSClientConfig;
     let ipfsClient: IPFSClient;
 
-    beforeEach(() => {
-        ipfsClientConfig = { apiKey: 'apiKey', baseUrl: 'baseUrl' };
+    beforeEach(async () => {
+        ipfsClientConfig = { apiKey: 'apiKey', baseUrl: 'baseUrl', provider: 'quicknode' };
         ipfsClient = new IPFSClient(ipfsClientConfig);
     });
 
-    describe('post', () => {
+    describe('post for QuickNode', () => {
         test('should post data successfully', async () => {
             // Mock fetch to return a resolved promise with a successful response
             (global.fetch as jest.Mock).mockResolvedValue({
@@ -33,13 +32,40 @@ describe('IPFSClient', () => {
         });
 
         test('should throw an error if the IPFS client is not initialized', async () => {
-            // Mock fetch to return a rejected promise with HTTP error 401
-            (global.fetch as jest.Mock).mockRejectedValue(new Error('Unauthorized'));
-
             // Arrange
             const data = 'someData';
             // Set ipfsClient's ipfs property to null to simulate an uninitialized state
-            ipfsClient.ipfs = null;
+            ipfsClient.initialized = false;
+        
+            // Act & Assert
+            await expect(ipfsClient.post(data)).rejects.toThrow('IPFS client not initialised properly');
+        });
+        
+    });
+
+    describe('post for Infura', () => {
+        beforeEach(() => {
+            ipfsClientConfig = { clientId: 'yourClientId', clientSecret: 'yourClientSecret', baseUrl: 'baseUrl', provider: 'infura' };
+            ipfsClient = new IPFSClient(ipfsClientConfig);
+        });
+
+        test('should post data successfully', async () => {
+            // Arrange
+            const data = 'someData';
+
+            // Act
+            console.log(ipfsClient)
+            const result = await ipfsClient.post(data);
+
+            // Assert
+            expect(result).toEqual('0xracoon');
+        });
+
+        test('should throw an error if the IPFS client is not initialized', async () => {
+            // Arrange
+            const data = 'someData';
+            // Set ipfsClient's ipfs property to null to simulate an uninitialized state
+            ipfsClient.initialized = false;
         
             // Act & Assert
             await expect(ipfsClient.post(data)).rejects.toThrow('IPFS client not initialised properly');

--- a/packages/client/src/ipfs/index.ts
+++ b/packages/client/src/ipfs/index.ts
@@ -3,49 +3,85 @@ import { IPFSClientConfig } from '../types';
 export default class IPFSClient {
   static readonly IPFS_CLIENT_ERROR = 'IPFS client not initialised';
   ipfs: any;
-  authorization: string;
+  authorization: string | undefined; 
+  provider: string | undefined;
+  initialized: boolean = false;
 
   constructor(ipfsClientConfig: IPFSClientConfig) {
-    this.authorization = ipfsClientConfig.apiKey;
+    this.provider = ipfsClientConfig.provider;
+    if (ipfsClientConfig.provider === 'quicknode') {
+      this.authorization = ipfsClientConfig.apiKey;
+      this.initialized = true;
+    }
+    else if (ipfsClientConfig.provider === 'infura') {
+      const authorization =
+        'Basic ' + btoa(ipfsClientConfig.clientId + ':' + ipfsClientConfig.clientSecret);
+      this.authorization = authorization;
+      import('kubo-rpc-client').then(({ create }) => {
+        this.ipfs = create({
+          url: ipfsClientConfig.baseUrl,
+          headers: {
+            authorization,
+          },
+        });
+      });
+      this.initialized = true;
+    }
   }
 
   public async post(data: string): Promise<string> {
-    const myHeaders = new Headers();
-    myHeaders.append("x-api-key", this.authorization);
-    myHeaders.append("Content-Type", "application/json");
+    if (!this.initialized) {
+      throw Error('IPFS client not initialised properly');
+    }
 
-    const raw = JSON.stringify({
-      "cid": data, // Assuming data already contains the CID
-      "name": "image.png",
-      "origins": [
-        "/ip4/123.12.113.142/tcp/4001/p2p/SourcePeerId",
-        "/ip4/123.12.113.114/udp/4001/quic/p2p/SourcePeerId"
-      ],
-      "meta": {
-        "test": "mycooltest",
-        "morevalue": {
-          "location": "/home"
+    if (this.authorization) {
+      if (this.provider === 'quicknode') {
+        const myHeaders = new Headers();
+        myHeaders.append("x-api-key", this.authorization);
+        myHeaders.append("Content-Type", "application/json");
+
+        const raw = JSON.stringify({
+          "cid": data, // Assuming data already contains the CID
+          "name": "image.png",
+          "origins": [
+            "/ip4/123.12.113.142/tcp/4001/p2p/SourcePeerId",
+            "/ip4/123.12.113.114/udp/4001/quic/p2p/SourcePeerId"
+          ],
+          "meta": {
+            "test": "mycooltest",
+            "morevalue": {
+              "location": "/home"
+            }
+          }
+        });
+
+        const requestOptions = {
+          method: 'POST',
+          headers: myHeaders,
+          body: raw,
+          redirect: 'follow' as RequestRedirect
+        };
+
+        try {
+          const response = await fetch("https://api.quicknode.com/ipfs/rest/v1/pinning", requestOptions);
+          if (!response.ok) {
+            throw new Error(`HTTP error! Status: ${response.status}`);
+          }
+          const result = await response.text();
+          return result;
+        } catch (error) {
+          console.error('Error:', error);
+          throw new Error(`IPFS client not initialised properly`);
         }
+      } else if (this.provider === 'infura') {
+        const result = await this.ipfs.add(data);
+        await this.ipfs.pin.add(result.path);
+        return result.path;
+      } else {
+        throw new Error('Invalid provider specified');
       }
-    });
-
-    const requestOptions = {
-      method: 'POST',
-      headers: myHeaders,
-      body: raw,
-      redirect: 'follow' as RequestRedirect
-    };
-
-    try {
-      const response = await fetch("https://api.quicknode.com/ipfs/rest/v1/pinning", requestOptions);
-      if (!response.ok) {
-        throw new Error(`HTTP error! Status: ${response.status}`);
-      }
-      const result = await response.text();
-      return result;
-    } catch (error) {
-      console.error('Error:', error);
-      throw new Error(`IPFS client not initialised properly`);
+    } else {
+      throw new Error('Authorization token not provided');
     }
   }
 }

--- a/packages/client/src/ipfs/index.ts
+++ b/packages/client/src/ipfs/index.ts
@@ -3,34 +3,49 @@ import { IPFSClientConfig } from '../types';
 export default class IPFSClient {
   static readonly IPFS_CLIENT_ERROR = 'IPFS client not initialised';
   ipfs: any;
-  authorization: any;
+  authorization: string;
 
   constructor(ipfsClientConfig: IPFSClientConfig) {
-    const authorization =
-      'Basic ' + btoa(ipfsClientConfig.clientId + ':' + ipfsClientConfig.clientSecret);
-    this.authorization = authorization;
-    // ipfs-http-client is being mocked by src/__mocks__/ipfs-http-client
-    // due to the way its being imported in ipfs/index.ts, we have to add a special mock for it
-    import('ipfs-http-client').then(({ create }) => {
-      this.ipfs = create({
-        url: ipfsClientConfig.baseUrl,
-        headers: {
-          authorization,
-        },
-      });
-    });
+    this.authorization = ipfsClientConfig.apiKey;
   }
 
   public async post(data: string): Promise<string> {
-    const formData = new FormData();
-    formData.append('file', new Blob([data], { type: 'application/json' }));
+    const myHeaders = new Headers();
+    myHeaders.append("x-api-key", this.authorization);
+    myHeaders.append("Content-Type", "application/json");
 
-    if (this.ipfs) {
-      const result = await this.ipfs.add(data);
-      await this.ipfs.pin.add(result.path);
-      return result.path;
+    const raw = JSON.stringify({
+      "cid": data, // Assuming data already contains the CID
+      "name": "image.png",
+      "origins": [
+        "/ip4/123.12.113.142/tcp/4001/p2p/SourcePeerId",
+        "/ip4/123.12.113.114/udp/4001/quic/p2p/SourcePeerId"
+      ],
+      "meta": {
+        "test": "mycooltest",
+        "morevalue": {
+          "location": "/home"
+        }
+      }
+    });
+
+    const requestOptions = {
+      method: 'POST',
+      headers: myHeaders,
+      body: raw,
+      redirect: 'follow' as RequestRedirect
+    };
+
+    try {
+      const response = await fetch("https://api.quicknode.com/ipfs/rest/v1/pinning", requestOptions);
+      if (!response.ok) {
+        throw new Error(`HTTP error! Status: ${response.status}`);
+      }
+      const result = await response.text();
+      return result;
+    } catch (error) {
+      console.error('Error:', error);
+      throw new Error(`IPFS client not initialised properly`);
     }
-
-    throw Error('IPFS client not intiialised properly');
   }
 }

--- a/packages/client/src/ipfs/index.ts
+++ b/packages/client/src/ipfs/index.ts
@@ -40,25 +40,10 @@ export default class IPFSClient {
         myHeaders.append("x-api-key", this.authorization);
         myHeaders.append("Content-Type", "application/json");
 
-        const raw = JSON.stringify({
-          "cid": data, // Assuming data already contains the CID
-          "name": "image.png",
-          "origins": [
-            "/ip4/123.12.113.142/tcp/4001/p2p/SourcePeerId",
-            "/ip4/123.12.113.114/udp/4001/quic/p2p/SourcePeerId"
-          ],
-          "meta": {
-            "test": "mycooltest",
-            "morevalue": {
-              "location": "/home"
-            }
-          }
-        });
-
         const requestOptions = {
           method: 'POST',
           headers: myHeaders,
-          body: raw,
+          body: data,
           redirect: 'follow' as RequestRedirect
         };
 

--- a/packages/client/src/ipfs/index.ts
+++ b/packages/client/src/ipfs/index.ts
@@ -3,29 +3,46 @@ import { IPFSClientConfig } from '../types';
 export default class IPFSClient {
   static readonly IPFS_CLIENT_ERROR = 'IPFS client not initialised';
   ipfs: any;
-  authorization: string | undefined; 
+  authorization: string | undefined;
   provider: string | undefined;
   initialized: boolean = false;
 
   constructor(ipfsClientConfig: IPFSClientConfig) {
-    this.provider = ipfsClientConfig.provider;
-    if (ipfsClientConfig.provider === 'quicknode') {
-      this.authorization = ipfsClientConfig.apiKey;
-      this.initialized = true;
-    }
-    else if (ipfsClientConfig.provider === 'infura') {
-      const authorization =
-        'Basic ' + btoa(ipfsClientConfig.clientId + ':' + ipfsClientConfig.clientSecret);
-      this.authorization = authorization;
-      import('kubo-rpc-client').then(({ create }) => {
-        this.ipfs = create({
-          url: ipfsClientConfig.baseUrl,
-          headers: {
-            authorization,
-          },
+    switch (ipfsClientConfig.provider) {
+      case 'quicknode':
+        this.authorization = ipfsClientConfig.apiKey;
+        this.provider = 'quicknode';
+        this.initialized = true;
+        break;
+      case 'infura':
+        const authorization = 'Basic ' + btoa(ipfsClientConfig.clientId + ':' + ipfsClientConfig.clientSecret);
+        this.authorization = authorization;
+        this.provider = 'infura';
+        import('kubo-rpc-client').then(({ create }) => {
+          this.ipfs = create({
+            url: ipfsClientConfig.baseUrl,
+            headers: {
+              authorization,
+            },
+          });
         });
-      });
-      this.initialized = true;
+        this.initialized = true;
+        break;
+      default:
+        // Assume Infura if no provider is defined
+        const defaultAuthorization = 'Basic ' + btoa(ipfsClientConfig.clientId + ':' + ipfsClientConfig.clientSecret);
+        this.authorization = defaultAuthorization;
+        this.provider = 'infura';
+        import('kubo-rpc-client').then(({ create }) => {
+          this.ipfs = create({
+            url: ipfsClientConfig.baseUrl,
+            headers: {
+              authorization: defaultAuthorization,
+            },
+          });
+        });
+        this.initialized = true;
+        break;
     }
   }
 
@@ -33,40 +50,47 @@ export default class IPFSClient {
     if (!this.initialized) {
       throw Error('IPFS client not initialised properly');
     }
-
-    if (this.authorization) {
-      if (this.provider === 'quicknode') {
-        const myHeaders = new Headers();
-        myHeaders.append("x-api-key", this.authorization);
-        myHeaders.append("Content-Type", "application/json");
-
-        const requestOptions = {
-          method: 'POST',
-          headers: myHeaders,
-          body: data,
-          redirect: 'follow' as RequestRedirect
-        };
-
-        try {
-          const response = await fetch("https://api.quicknode.com/ipfs/rest/v1/pinning", requestOptions);
-          if (!response.ok) {
-            throw new Error(`HTTP error! Status: ${response.status}`);
-          }
-          const result = await response.text();
-          return result;
-        } catch (error) {
-          console.error('Error:', error);
-          throw new Error(`IPFS client not initialised properly`);
-        }
-      } else if (this.provider === 'infura') {
+    if (!this.authorization) {
+      throw new Error('Authorization token not provided')
+    }
+    switch (this.provider) {
+      case 'quicknode':
+        return this.handleQuicknode(data);
+      case 'infura':
         const result = await this.ipfs.add(data);
         await this.ipfs.pin.add(result.path);
         return result.path;
-      } else {
+      default:
         throw new Error('Invalid provider specified');
-      }
-    } else {
+    }
+  }
+
+  private async handleQuicknode(data: string): Promise<string> {
+    if (this.authorization === undefined) {
       throw new Error('Authorization token not provided');
+    }
+  
+    const myHeaders = new Headers();
+    myHeaders.append("x-api-key", this.authorization);
+    myHeaders.append("Content-Type", "application/json");
+  
+    const requestOptions = {
+      method: 'POST',
+      headers: myHeaders,
+      body: data,
+      redirect: 'follow' as RequestRedirect
+    };
+  
+    try {
+      const response = await fetch("https://api.quicknode.com/ipfs/rest/v1/pinning", requestOptions);
+      if (!response.ok) {
+        throw new Error(`HTTP error! Status: ${response.status}`);
+      }
+      const result = await response.text();
+      return result;
+    } catch (error) {
+      console.error('Error:', error);
+      throw new Error(`IPFS client not initialised properly`);
     }
   }
 }

--- a/packages/client/src/types/index.ts
+++ b/packages/client/src/types/index.ts
@@ -35,8 +35,7 @@ export type GraphQLConfig = {
 export type GraphQLQuery = string;
 
 export type IPFSClientConfig = {
-  clientId: string;
-  clientSecret: string;
+  apiKey: string;
   baseUrl: string;
 };
 

--- a/packages/client/src/types/index.ts
+++ b/packages/client/src/types/index.ts
@@ -35,7 +35,7 @@ export type GraphQLConfig = {
 export type GraphQLQuery = string;
 
 export type IPFSClientConfig = {
-  provider: 'quicknode' | 'infura'; 
+  provider?: 'quicknode' | 'infura'; 
   apiKey?: string; 
   baseUrl: string; 
   clientId?: string; 

--- a/packages/client/src/types/index.ts
+++ b/packages/client/src/types/index.ts
@@ -35,8 +35,11 @@ export type GraphQLConfig = {
 export type GraphQLQuery = string;
 
 export type IPFSClientConfig = {
-  apiKey: string;
-  baseUrl: string;
+  provider: 'quicknode' | 'infura'; 
+  apiKey?: string; 
+  baseUrl: string; 
+  clientId?: string; 
+  clientSecret?: string; 
 };
 
 export type ViemClientConfig = {


### PR DESCRIPTION
Users now have the option to select their IPFS provider from either Infura or Quicknode. When initializing 'ipfsConfig', they will need to include an additional parameter 'provider', specifying either 'infura' or 'quicknode'.